### PR TITLE
beamWeightsFromFunction.m: include design conversion to polar coords as required by directSHT function

### DIFF
--- a/TEST_SCRIPTS.m
+++ b/TEST_SCRIPTS.m
@@ -906,7 +906,7 @@ h = gcf; h.Position(3) = 1.5*h.Position(3); h.Position(4) = 1.5*h.Position(4);
 %
 % The following code examples illustrates use of these methods.
 
-%%% ---Sigle source case
+%%% ---Single source case
 %
 % In the basic mixture of a single point/plane wave source, and an
 % isotropic diffuse field, all estimators perform well. More specifically

--- a/beamWeightsFromFunction.m
+++ b/beamWeightsFromFunction.m
@@ -18,6 +18,8 @@ function b_nm = beamWeightsFromFunction(fHandleArray, order)
 
 % get a dense uniform design
 [~, dirsAziElev] = getTdesign(20);
+% convert azi-elev to azi-incl
+dirsAziInc = [dirsAziElev(:,1) pi/2-dirsAziElev(:,2)];
 
 Nfunc = length(fHandleArray);
 b_nm = zeros((order+1)^2, Nfunc);


### PR DESCRIPTION
It seems at some point the conversion to polar coordinates was removed, which breaks `beamWeightsFromFunction`. This restores that conversion.