### PR TITLE
Confine pvsig_buf to 4 channels (pressure + velocity). Correct  nBuf,…

### DIFF
--- a/TEST_SCRIPTS.m
+++ b/TEST_SCRIPTS.m
@@ -851,10 +851,11 @@ pvsig = M_sh2pv*shsig(1:4,:);
 % partition the signal into 100 sample buffers with 50% overlap
 lBuf = 100;
 lHop = 50;
-nBuf = lSig/lHop;
-pvsig_buf = zeros(nSH, lBuf, lSig/lHop);
-for ns=1:nSH
-    pvsig_buf(ns,:,:) = buffer(pvsig(ns,:)', lBuf, lHop);
+lOvlp = lBuf - lHop;
+nBuf = ceil(lSig/lHop);
+pvsig_buf = zeros(4, lBuf, nBuf);
+for ns=1:4
+    pvsig_buf(ns,:,:) = buffer(pvsig(ns,:)', lBuf, lOvlp);
 end
 % compute correlations of pressure-velocity for each partition, for
 % short-time estimates of intensity vector


### PR DESCRIPTION
… lHop calculations.

- Previously a the pressure + velocity signal buffer allocated channels for all SH channels, when only 4 are needed/used.
- Pass an overlap size to `buffer` instead of `lHop`, to align with the function definition.
- Add `ceil` to the `nBuf` calculation to be robust against varying signal lengths and match the result from `buffer` operation (`buffer` will zero pad the signal by the overlap amount).